### PR TITLE
Add default destructors to interface classes to make them future proof

### DIFF
--- a/lib/Communication/IRobotIOStream.h
+++ b/lib/Communication/IRobotIOStream.h
@@ -8,6 +8,8 @@ class IRobotIOStream
 {
 
 public:
+    virtual ~IRobotIOStream() = default;
+
     virtual int available() = 0;
     virtual int read() = 0;
     virtual size_t write(uint8_t c) = 0;

--- a/lib/Communication/InputStreamParser.h
+++ b/lib/Communication/InputStreamParser.h
@@ -3,25 +3,27 @@
 
 class IRobotIOStream;
 
-enum class JoystickCommand { NO_COMMAND = 0, UP, RIGHT, DOWN, LEFT, UP_TRIANGLE, RIGHT_CIRCLE, DOWN_X, LEFT_SQUARE }; 
+enum class JoystickCommand { NO_COMMAND = 0, UP, RIGHT, DOWN, LEFT, UP_TRIANGLE, RIGHT_CIRCLE, DOWN_X, LEFT_SQUARE };
 
 /**
- * Interface for decoding information coming from user to robot 
+ * Interface for decoding information coming from user to robot
  */
 class InputStreamParser
-{    
+{
     const int MIN_ALLOWED_CHAR = 'a';
     const int MAX_ALLOWED_CHAR = 'h';
 
 public:
+    virtual ~InputStreamParser() = default;
+
     /**
-     * Decode data coming from user to robot 
+     * Decode data coming from user to robot
      */
     virtual JoystickCommand decode(IRobotIOStream &input_stream) = 0;
 
-protected: 
+protected:
     bool is_allowed_cmd_char(char in)
-    {        
+    {
         if((in >= MIN_ALLOWED_CHAR) && (in <= MAX_ALLOWED_CHAR))
         {
             return true;
@@ -66,7 +68,7 @@ protected:
 
         }
 
-        return command; 
+        return command;
     };
 };
 

--- a/lib/Control/IFilter.h
+++ b/lib/Control/IFilter.h
@@ -8,6 +8,8 @@ template <typename T>
 class IFilter
 {
 public:
+    virtual ~IFilter() = default;
+
     /**
      * Get next filter output value
      * @param[in] input filters input for current step

--- a/lib/Sensing/IDistanceSensor.h
+++ b/lib/Sensing/IDistanceSensor.h
@@ -3,9 +3,11 @@
 
 /**
  * Interface for sensors measuring distance
- */ 
+ */
 class IDistanceSensor {
 public:
+    virtual ~IDistanceSensor() = default;
+
     /**
      * Command sensor to measure distance
      * @return true if measurement was successful, false otherwise


### PR DESCRIPTION
This change adds default virtual destructors to all interfaces. They aren't required now but prevent future issues from missing virtual destructors.