### PR TITLE
Fix PD regulator computation

### DIFF
--- a/lib/Control/Regulator.h
+++ b/lib/Control/Regulator.h
@@ -113,9 +113,12 @@ protected:
         {
             m_first_run = false;
             m_last_e = e; 
+            return this->m_gain * e;
         }
 
-        return this->m_gain * e + (e - m_last_e) * m_D_gain;
+        T result = this->m_gain * e + (e - m_last_e) * m_D_gain;
+        m_last_e = e;
+        return result;
     }
 
 public:


### PR DESCRIPTION
This changes fixes broken PD regulator computation. This regulator is currently not in use, but it will be needed for future experiments. 