### PR TITLE
Fix overflow when converting ADC value to mVDC

### DIFF
--- a/lib/Sensing/ArduinoBatterySensor.cpp
+++ b/lib/Sensing/ArduinoBatterySensor.cpp
@@ -8,5 +8,6 @@ uint16_t ArduinoBatterySensor::get_battery_voltage_adc() {
 }
 
 uint16_t ArduinoBatterySensor::get_battery_voltage_mVDC() {
-  return analogRead(SNS_BATTERY_VLTG) * ADC_REFERENCE_mV / ADC_MAX;
+  // static cast to uint32_t to avoid overflow during multiplication
+  return static_cast<uint32_t>(analogRead(SNS_BATTERY_VLTG)) * ADC_REFERENCE_mV / ADC_MAX;
 }


### PR DESCRIPTION
Multiplication in the adc to mVDC formula caused an overflow of AVR's int, which has only 16 bits. 