### PR TITLE
Make BLE Joystick Decoder non-blocking

### DIFF
--- a/lib/Communication/BLEJoystickDecoder.h
+++ b/lib/Communication/BLEJoystickDecoder.h
@@ -19,6 +19,8 @@ enum class JoystickDecoderState {
 class BLEJoystickDecoder : public InputStreamParser {
   JoystickDecoderState state = JoystickDecoderState::WAITING_FOR_UPPER;
   int prev = 0;
+  int chars_processed = 0;
+  const int MAX_CHARS_PER_ITER = 10;
 public:
   /**
    * Decode input format into JoystickCommand format
@@ -30,38 +32,37 @@ public:
     int current;
     const int DIFF_LOWER_UPPER = 'a' - 'A';
 
-    if (!input_stream.available()) {
-      return JoystickCommand::NO_COMMAND;
-    }
+    while (input_stream.available() && chars_processed++ < MAX_CHARS_PER_ITER) {
 
-    current = input_stream.read();
+      current = input_stream.read();
 
-    switch (state) {
-    case JoystickDecoderState::WAITING_FOR_UPPER:
-      if (isupper(current)) {
-        state = JoystickDecoderState::WAITING_FOR_LOWER;
-        prev = current;
-      }
-      break;
-    case JoystickDecoderState::WAITING_FOR_LOWER:
-      if (islower(current) && current - prev == DIFF_LOWER_UPPER) {
-        state = JoystickDecoderState::WAITING_FOR_ZERO;
-        prev = current;
-      } else {
+      switch (state) {
+      case JoystickDecoderState::WAITING_FOR_UPPER:
+        if (isupper(current)) {
+          state = JoystickDecoderState::WAITING_FOR_LOWER;
+          prev = current;
+        }
+        break;
+      case JoystickDecoderState::WAITING_FOR_LOWER:
+        if (islower(current) && current - prev == DIFF_LOWER_UPPER) {
+          state = JoystickDecoderState::WAITING_FOR_ZERO;
+          prev = current;
+        } else {
+          state = JoystickDecoderState::WAITING_FOR_UPPER;
+        }
+        break;
+      case JoystickDecoderState::WAITING_FOR_ZERO:
         state = JoystickDecoderState::WAITING_FOR_UPPER;
-      }
-      break;
-    case JoystickDecoderState::WAITING_FOR_ZERO:
-      state = JoystickDecoderState::WAITING_FOR_UPPER;
-      if (current == '\0') {
-        return input_to_joystick_command(prev);
-      }
+        if (current == '\0') {
+          return input_to_joystick_command(prev);
+        }
 
-      break;
+        break;
+      }
     }
 
     return JoystickCommand::NO_COMMAND;
-  };
+  }
 };
 
 #endif

--- a/lib/Communication/BLEJoystickDecoder.h
+++ b/lib/Communication/BLEJoystickDecoder.h
@@ -3,6 +3,13 @@
 
 #include "IRobotIOStream.h"
 #include "InputStreamParser.h"
+#include <ctype.h>
+
+enum class JoystickDecoderState {
+  WAITING_FOR_UPPER = 0,
+  WAITING_FOR_LOWER,
+  WAITING_FOR_ZERO
+};
 
 /**
  * Implementation of communication protocol used by BLEJoystick application,
@@ -10,46 +17,50 @@
  * zero for each button press -> buttons are labeled from A to H
  */
 class BLEJoystickDecoder : public InputStreamParser {
+  JoystickDecoderState state = JoystickDecoderState::WAITING_FOR_UPPER;
+  int prev = 0;
+public:
   /**
-   * Decode input format into JoysticCommand format
+   * Decode input format into JoystickCommand format
    * @param input_stream stream to receive input data from
-   * @return decoded command in JoysticCommand format, or
+   * @return decoded command in JoystickCommand format, or
    * JoystickCommand::NO_COMMAND if no command was present
    */
   JoystickCommand decode(IRobotIOStream &input_stream) override {
-    JoystickCommand command = JoystickCommand::NO_COMMAND;
-    char current, prev;
-    bool waiting4zero = false;
+    int current;
     const int DIFF_LOWER_UPPER = 'a' - 'A';
 
-    // TODO: remove this active waiting, just check it and go
-    while (!input_stream.available()) {
-      ;
+    if (!input_stream.available()) {
+      return JoystickCommand::NO_COMMAND;
     }
 
-    prev = input_stream.read();
+    current = input_stream.read();
 
-    while (command == JoystickCommand::NO_COMMAND) {
-      while (!input_stream.available()) {
-        ;
+    switch (state) {
+    case JoystickDecoderState::WAITING_FOR_UPPER:
+      if (isupper(current)) {
+        state = JoystickDecoderState::WAITING_FOR_LOWER;
+        prev = current;
+      }
+      break;
+    case JoystickDecoderState::WAITING_FOR_LOWER:
+      if (islower(current) && current - prev == DIFF_LOWER_UPPER) {
+        state = JoystickDecoderState::WAITING_FOR_ZERO;
+        prev = current;
+      } else {
+        state = JoystickDecoderState::WAITING_FOR_UPPER;
+      }
+      break;
+    case JoystickDecoderState::WAITING_FOR_ZERO:
+      state = JoystickDecoderState::WAITING_FOR_UPPER;
+      if (current == '\0') {
+        return input_to_joystick_command(prev);
       }
 
-      current = input_stream.read();
-
-      if (waiting4zero) {
-        if (current == 0) {
-          command = input_to_joystick_command(prev);
-        } else {
-          waiting4zero = false;
-        }
-      } else if (current - prev == DIFF_LOWER_UPPER) {
-        waiting4zero = true;
-      }
-
-      prev = current;
+      break;
     }
 
-    return command;
+    return JoystickCommand::NO_COMMAND;
   };
 };
 

--- a/lib/Communication/BLEJoystickDecoder.h
+++ b/lib/Communication/BLEJoystickDecoder.h
@@ -1,68 +1,56 @@
 #ifndef BLEJOYSTICK_DECODER_H
 #define BLEJOYSTICK_DECODER_H
 
-#include "InputStreamParser.h"
 #include "IRobotIOStream.h"
+#include "InputStreamParser.h"
 
 /**
  * Implementation of communication protocol used by BLEJoystick application,
- * which sends commands in format "Aa\0" -> Upper case, lower case, 
+ * which sends commands in format "Aa\0" -> Upper case, lower case,
  * zero for each button press -> buttons are labeled from A to H
- */ 
-class BLEJoystickDecoder : public InputStreamParser
-{
-    /**
-     * Decode input format into JoysticCommand format
-     * @param input_stream stream to receive input data from
-     * @return decoded command in JoysticCommand format, or JoystickCommand::NO_COMMAND 
-     * if no command was present
-     */
-    JoystickCommand decode(IRobotIOStream &input_stream) override
-    {
-        JoystickCommand command = JoystickCommand::NO_COMMAND; 
-        char current, prev;
-        bool waiting4zero = false;
-        const int DIFF_LOWER_UPPER = 'a' - 'A';
+ */
+class BLEJoystickDecoder : public InputStreamParser {
+  /**
+   * Decode input format into JoysticCommand format
+   * @param input_stream stream to receive input data from
+   * @return decoded command in JoysticCommand format, or
+   * JoystickCommand::NO_COMMAND if no command was present
+   */
+  JoystickCommand decode(IRobotIOStream &input_stream) override {
+    JoystickCommand command = JoystickCommand::NO_COMMAND;
+    char current, prev;
+    bool waiting4zero = false;
+    const int DIFF_LOWER_UPPER = 'a' - 'A';
 
-        // TODO: remove this active waiting, just check it and go
-        while(!input_stream.available())
-        {
-            ;
+    // TODO: remove this active waiting, just check it and go
+    while (!input_stream.available()) {
+      ;
+    }
+
+    prev = input_stream.read();
+
+    while (command == JoystickCommand::NO_COMMAND) {
+      while (!input_stream.available()) {
+        ;
+      }
+
+      current = input_stream.read();
+
+      if (waiting4zero) {
+        if (current == 0) {
+          command = input_to_joystick_command(prev);
+        } else {
+          waiting4zero = false;
         }
+      } else if (current - prev == DIFF_LOWER_UPPER) {
+        waiting4zero = true;
+      }
 
-        prev = input_stream.read();
+      prev = current;
+    }
 
-        while(command == JoystickCommand::NO_COMMAND) 
-        {
-            while(!input_stream.available())
-            {
-            ;
-            }
-            
-            current = input_stream.read();
-
-            if(waiting4zero)
-            {      
-            if(current == 0)
-            {
-                command = input_to_joystick_command(prev);
-            }
-            else
-            {
-                waiting4zero = false;
-            }      
-            }
-            else if(current - prev == DIFF_LOWER_UPPER) 
-            {
-            waiting4zero = true;
-            }
-
-            prev = current; 
-        }
-
-        return command; 
-    
-    };
+    return command;
+  };
 };
 
-#endif 
+#endif

--- a/lib/Communication/OvladackaParser.h
+++ b/lib/Communication/OvladackaParser.h
@@ -1,74 +1,68 @@
 #ifndef OVLADACKA_PARSER_H
 #define OVLADACKA_PARSER_H
 
-#include "InputStreamParser.h"
 #include "IRobotIOStream.h"
+#include "InputStreamParser.h"
 
-enum class OvladackaParserState { WAITING_FOR_START = 0, WAITING_FOR_CMD, WAITING_FOR_ACK }; 
-
+enum class OvladackaParserState {
+  WAITING_FOR_START = 0,
+  WAITING_FOR_CMD,
+  WAITING_FOR_ACK
+};
 
 /**
  * Implementation of communication protocol used by ovladacka tool
  */
-class OvladackaParser : public InputStreamParser
-{
-    OvladackaParserState state = OvladackaParserState::WAITING_FOR_START;
-    const char START_CHAR = ':';
-    const char ACK_CHAR = '!';
-    char cmd_char = 0;
+class OvladackaParser : public InputStreamParser {
+  OvladackaParserState state = OvladackaParserState::WAITING_FOR_START;
+  const char START_CHAR = ':';
+  const char ACK_CHAR = '!';
+  char cmd_char = 0;
+
 public:
-    /**
-     * Decode input format into JoysticCommand format
-     * @param input_stream stream to receive input data from
-     * @return decoded command in JoysticCommand format, or JoystickCommand::NO_COMMAND 
-     * if no command was present
-     */
-    JoystickCommand decode(IRobotIOStream &input_stream) override
-    {
-        JoystickCommand command = JoystickCommand::NO_COMMAND; 
-        int chars_processed = 0;
-        const int MAX_CHARS_PER_ITER = 10;
+  /**
+   * Decode input format into JoysticCommand format
+   * @param input_stream stream to receive input data from
+   * @return decoded command in JoysticCommand format, or
+   * JoystickCommand::NO_COMMAND if no command was present
+   */
+  JoystickCommand decode(IRobotIOStream &input_stream) override {
+    JoystickCommand command = JoystickCommand::NO_COMMAND;
+    int chars_processed = 0;
+    const int MAX_CHARS_PER_ITER = 10;
 
-        /* Limit number of characters to be processed in a row to prevent situation when
-         * a long stream of incomming characters causes this function to block others.
-         * Yes, we do need an OS and threads... */
-        while(input_stream.available() && chars_processed++ < MAX_CHARS_PER_ITER) 
-        {  
-            auto current = input_stream.read();
+    /* Limit number of characters to be processed in a row to prevent situation
+     * when a long stream of incoming characters causes this function to block
+     * others. Yes, we do need an OS and threads... */
+    while (input_stream.available() && chars_processed++ < MAX_CHARS_PER_ITER) {
+      auto current = input_stream.read();
 
-            switch (state)
-            {
-                case OvladackaParserState::WAITING_FOR_START:
-                    if (current == START_CHAR)
-                    {
-                        state = OvladackaParserState::WAITING_FOR_CMD;
-                    }
-                break;
-                case OvladackaParserState::WAITING_FOR_CMD:
-                    if (is_allowed_cmd_char(current))
-                    {
-                        state = OvladackaParserState::WAITING_FOR_ACK;
-                        cmd_char = current;
-                    }
-                    else 
-                    {
-                        state = OvladackaParserState::WAITING_FOR_START;
-                    }
-                break;
-                case OvladackaParserState::WAITING_FOR_ACK:
-                    if (current == ACK_CHAR)
-                    {
-                        command = input_to_joystick_command(cmd_char);                        
-                    }
-
-                    state = OvladackaParserState::WAITING_FOR_START;
-                break;
-            }                 
+      switch (state) {
+      case OvladackaParserState::WAITING_FOR_START:
+        if (current == START_CHAR) {
+          state = OvladackaParserState::WAITING_FOR_CMD;
+        }
+        break;
+      case OvladackaParserState::WAITING_FOR_CMD:
+        if (is_allowed_cmd_char(current)) {
+          state = OvladackaParserState::WAITING_FOR_ACK;
+          cmd_char = current;
+        } else {
+          state = OvladackaParserState::WAITING_FOR_START;
+        }
+        break;
+      case OvladackaParserState::WAITING_FOR_ACK:
+        if (current == ACK_CHAR) {
+          command = input_to_joystick_command(cmd_char);
         }
 
-        return command; 
-    };
+        state = OvladackaParserState::WAITING_FOR_START;
+        break;
+      }
+    }
 
+    return command;
+  };
 };
 
 #endif

--- a/lib/Communication/OvladackaParser.h
+++ b/lib/Communication/OvladackaParser.h
@@ -33,7 +33,7 @@ public:
 
     /* Limit number of characters to be processed in a row to prevent situation
      * when a long stream of incoming characters causes this function to block
-     * others. Yes, we do need an OS and threads... */
+     * others. */
     while (input_stream.available() && chars_processed++ < MAX_CHARS_PER_ITER) {
       auto current = input_stream.read();
 

--- a/test/communication/test_command_decoder/test_command_decoder.cpp
+++ b/test/communication/test_command_decoder/test_command_decoder.cpp
@@ -84,9 +84,7 @@ void test_check_external_command_speed_BLE_joy(void)
 
     rob_cmd_expected.desired_speed = 50;
 
-    for (int i = 0; i < sizeof(in_data) / sizeof(char); i++) {
-        ext_comm_dec.check_external_command(rob_cmd_actual);
-    }
+    ext_comm_dec.check_external_command(rob_cmd_actual);
 
     TEST_ASSERT_EQUAL_MEMORY(&rob_cmd_expected, &rob_cmd_actual, sizeof(rob_cmd_actual));
 }
@@ -104,9 +102,7 @@ void test_check_external_command_angle_BLE_joy(void)
 
     rob_cmd_expected.desired_servo_angle = 70;
 
-    for (int i = 0; i < sizeof(in_data) / sizeof(char); i++) {
-        ext_comm_dec.check_external_command(rob_cmd_actual);
-    }
+    ext_comm_dec.check_external_command(rob_cmd_actual);
 
     TEST_ASSERT_EQUAL_MEMORY(&rob_cmd_expected, &rob_cmd_actual, sizeof(rob_cmd_actual));
 }

--- a/test/communication/test_command_decoder/test_command_decoder.cpp
+++ b/test/communication/test_command_decoder/test_command_decoder.cpp
@@ -39,12 +39,12 @@ void test_check_external_command_speed_ovladacka(void)
 {
     OvladackaParser in_parser;
     char in_data[] = ":a!";
-    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char)); 
-    ArduinoSerialStream ard_stream(sim_uart); 
+    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char));
+    ArduinoSerialStream ard_stream(sim_uart);
     ExternalCommandDecoder ext_comm_dec(ard_stream, in_parser);
 
     RobotCommand rob_cmd_actual;
-    RobotCommand rob_cmd_expected;  
+    RobotCommand rob_cmd_expected;
 
     rob_cmd_expected.desired_speed = SPEED_INCREMENT;
 
@@ -57,12 +57,12 @@ void test_check_external_command_angle_ovladacka(void)
 {
     OvladackaParser in_parser;
     char in_data[] = ":b!";
-    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char)); 
-    ArduinoSerialStream ard_stream(sim_uart); 
+    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char));
+    ArduinoSerialStream ard_stream(sim_uart);
     ExternalCommandDecoder ext_comm_dec(ard_stream, in_parser);
 
     RobotCommand rob_cmd_actual;
-    RobotCommand rob_cmd_expected;  
+    RobotCommand rob_cmd_expected;
 
     rob_cmd_expected.desired_servo_angle = SERVO_CENTER - SERVO_INCREMENT;
 
@@ -74,17 +74,19 @@ void test_check_external_command_angle_ovladacka(void)
 void test_check_external_command_speed_BLE_joy(void)
 {
     BLEJoystickDecoder in_parser;
-    char in_data[] = "Aa\0"; // Command to increase speed in BLE Joystick format
-    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char)); 
+    char in_data[] = {'A', 'a', '\0'}; // Command to increase speed in BLE Joystick format
+    SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char));
     ArduinoSerialStream ard_stream(sim_uart);
     ExternalCommandDecoder ext_comm_dec(ard_stream, in_parser);
 
     RobotCommand rob_cmd_actual;
-    RobotCommand rob_cmd_expected;  
+    RobotCommand rob_cmd_expected;
 
     rob_cmd_expected.desired_speed = 50;
 
-    ext_comm_dec.check_external_command(rob_cmd_actual);
+    for (int i = 0; i < sizeof(in_data) / sizeof(char); i++) {
+        ext_comm_dec.check_external_command(rob_cmd_actual);
+    }
 
     TEST_ASSERT_EQUAL_MEMORY(&rob_cmd_expected, &rob_cmd_actual, sizeof(rob_cmd_actual));
 }
@@ -92,17 +94,19 @@ void test_check_external_command_speed_BLE_joy(void)
 void test_check_external_command_angle_BLE_joy(void)
 {
     BLEJoystickDecoder in_parser;
-    char in_data[] = "Bb\0"; // Command to decrease servo angle in BLE Joystick format
+    char in_data[] = {'B', 'b', '\0'}; // Command to decrease servo angle in BLE Joystick format
     SimulatedUART sim_uart(in_data, sizeof(in_data) / sizeof(char));
-    ArduinoSerialStream ard_stream(sim_uart); 
+    ArduinoSerialStream ard_stream(sim_uart);
     ExternalCommandDecoder ext_comm_dec(ard_stream, in_parser);
 
     RobotCommand rob_cmd_actual;
-    RobotCommand rob_cmd_expected;  
+    RobotCommand rob_cmd_expected;
 
     rob_cmd_expected.desired_servo_angle = 70;
 
-    ext_comm_dec.check_external_command(rob_cmd_actual);
+    for (int i = 0; i < sizeof(in_data) / sizeof(char); i++) {
+        ext_comm_dec.check_external_command(rob_cmd_actual);
+    }
 
     TEST_ASSERT_EQUAL_MEMORY(&rob_cmd_expected, &rob_cmd_actual, sizeof(rob_cmd_actual));
 }
@@ -110,17 +114,17 @@ void test_check_external_command_angle_BLE_joy(void)
 
 int main( int argc, char **argv) {
     UNITY_BEGIN();
-   
+
     RUN_TEST(test_simulated_uart);
     RUN_TEST(test_check_external_command_speed_ovladacka);
     RUN_TEST(test_check_external_command_angle_ovladacka);
 
     RUN_TEST(test_check_external_command_speed_BLE_joy);
     RUN_TEST(test_check_external_command_angle_BLE_joy);
-    
+
     UNITY_END();
 
     stop_simavr();
 
-    return 0; 
+    return 0;
 }


### PR DESCRIPTION
Instead of waiting for new character forever, just process up to ten of them, if they are available, return otherwise. Plus some minor refactoring. 