### PR TITLE
Convert camelCase identifiers to snake_case for consistency

### DIFF
--- a/lib/Communication/ArduinoRobotIndicators.cpp
+++ b/lib/Communication/ArduinoRobotIndicators.cpp
@@ -17,8 +17,8 @@ ArduinoRobotIndicators::ArduinoRobotIndicators() {
   digitalWrite(static_cast<unsigned int>(LEDPin::LED5), HIGH);
 }
 
-void ArduinoRobotIndicators::setLED(unsigned int pin, bool state) {
-  if (!isValidLED(pin))
+void ArduinoRobotIndicators::set_led(unsigned int pin, bool state) {
+  if (!is_valid_led(pin))
     return;
   digitalWrite(pin, state ? LOW : HIGH);
 }
@@ -27,19 +27,19 @@ int ArduinoRobotIndicators::indicate_robot_state(RobotIndicatorState state) {
   switch (state) {
   case RobotIndicatorState::MOVING_AVOIDING:
     // Indicate avoiding state (LED1 off, LED2 on)
-    setLED(static_cast<unsigned int>(LEDPin::LED1), false);
-    setLED(static_cast<unsigned int>(LEDPin::LED2), true);
+    set_led(static_cast<unsigned int>(LEDPin::LED1), false);
+    set_led(static_cast<unsigned int>(LEDPin::LED2), true);
     break;
   case RobotIndicatorState::MOVING_FOLLOWING:
     // Indicate following state (LED1 on, LED2 off)
-    setLED(static_cast<unsigned int>(LEDPin::LED1), true);
-    setLED(static_cast<unsigned int>(LEDPin::LED2), false);
+    set_led(static_cast<unsigned int>(LEDPin::LED1), true);
+    set_led(static_cast<unsigned int>(LEDPin::LED2), false);
     break;
   case RobotIndicatorState::IDLE:
   case RobotIndicatorState::ERROR:
     // Indicate idle state (LED1 off, LED2 off)
-    setLED(static_cast<unsigned int>(LEDPin::LED1), false);
-    setLED(static_cast<unsigned int>(LEDPin::LED2), false);
+    set_led(static_cast<unsigned int>(LEDPin::LED1), false);
+    set_led(static_cast<unsigned int>(LEDPin::LED2), false);
     break;
   }
 
@@ -48,6 +48,6 @@ int ArduinoRobotIndicators::indicate_robot_state(RobotIndicatorState state) {
 
 int ArduinoRobotIndicators::indicate_battery_warning() {
   // Toggle battery warning LED (LED5)
-  toggleBatteryLED();
+  toggle_battery_led();
   return 0;
 }

--- a/lib/Communication/ArduinoRobotIndicators.h
+++ b/lib/Communication/ArduinoRobotIndicators.h
@@ -34,7 +34,7 @@ private:
    * @param[in] pin LED pin to validate
    * @return true if pin is valid, false otherwise
    */
-  bool isValidLED(unsigned int pin) const {
+  bool is_valid_led(unsigned int pin) const {
     return pin >= MIN_LED_PIN && pin <= MAX_LED_PIN;
   }
 
@@ -43,14 +43,14 @@ private:
    * @param[in] pin LED pin (use LEDPin enum)
    * @param[in] state true to turn on, false to turn off
    */
-  void setLED(unsigned int pin, bool state);
+  void set_led(unsigned int pin, bool state);
 
   /**
    * Toggle battery indicator LED state
    */
-  void toggleBatteryLED() {
+  void toggle_battery_led() {
     battery_led_on = !battery_led_on;
-    setLED(static_cast<unsigned int>(BATTERY_LED), battery_led_on);
+    set_led(static_cast<unsigned int>(BATTERY_LED), battery_led_on);
   }
 
 public:

--- a/lib/Control/TimeManager.h
+++ b/lib/Control/TimeManager.h
@@ -4,13 +4,13 @@
 /**
  * Class to check if it is time to perform certain action
  */
-class TimeManager 
+class TimeManager
 {
-    unsigned long lastStatusMillis = 0;
-    unsigned long lastCommandMillis = 0;
+    unsigned long last_status_millis = 0;
+    unsigned long last_command_millis = 0;
 
-    bool firstPassStatus = true;
-    bool firstPassCommand = true; 
+    bool first_pass_status = true;
+    bool first_pass_command = true;
 
     static const int STATUS_PRINT_INTERVAL_MS = 1000;
     static const int COMMAND_INTERVAL_MS = 100;
@@ -18,36 +18,36 @@ class TimeManager
 public:
     /**
      * Check if enough time elapsed to perform status check
-     * @param[in] currentMillis current system time in ms
+     * @param[in] current_millis current system time in ms
      * @return true if time elapsed from last status check is greater than threshold, false otherwise
      */
-    bool isTimeForStatusCheck(unsigned long currentMillis)
+    bool is_time_for_status_check(unsigned long current_millis)
     {
-        if((currentMillis - lastStatusMillis > STATUS_PRINT_INTERVAL_MS) || firstPassStatus )
+        if((current_millis - last_status_millis > STATUS_PRINT_INTERVAL_MS) || first_pass_status )
         {
-            lastStatusMillis = currentMillis; 
-            firstPassStatus = false;
+            last_status_millis = current_millis;
+            first_pass_status = false;
             return true;
         }
 
-        return false;         
+        return false;
     }
 
     /**
      * Check if enough time elapsed to perform automatic operation
-     * @param[in] currentMillis current system time in ms
+     * @param[in] current_millis current system time in ms
      * @return true if time elapsed from last automatic operation is greater than threshold, false otherwise
      */
-    bool isTimeForAutomaticCommand(unsigned long currentMillis)
+    bool is_time_for_automatic_command(unsigned long current_millis)
     {
-        if((currentMillis - lastCommandMillis > COMMAND_INTERVAL_MS) || firstPassCommand)
+        if((current_millis - last_command_millis > COMMAND_INTERVAL_MS) || first_pass_command)
         {
-            lastCommandMillis = currentMillis;
-            firstPassCommand = false; 
+            last_command_millis = current_millis;
+            first_pass_command = false;
             return true;
         }
 
-        return false; 
+        return false;
     }
 };
 

--- a/lib/Motion/Motion.cpp
+++ b/lib/Motion/Motion.cpp
@@ -18,8 +18,8 @@ bool Motion::set_angle(int angle) {
     return false;
   }
 
-  if (oldServo != angle) {
-    oldServo = angle;
+  if (old_servo != angle) {
+    old_servo = angle;
     steering_servo.set_angle(angle);
   } else {
     return false;

--- a/lib/Motion/Motion.h
+++ b/lib/Motion/Motion.h
@@ -10,7 +10,7 @@
  */
 class Motion {
   int prev_speed = 0;
-  int oldServo = 0;
+  int old_servo = 0;
   IMotorController &motor;
   ISteeringServo &steering_servo;
   bool disabled = false;

--- a/src/PollingRobotRunner.h
+++ b/src/PollingRobotRunner.h
@@ -13,11 +13,11 @@ public:
       robot.check_external_command();
       robot.apply_motion_command();
 
-      if (time_manager.isTimeForStatusCheck(now_ms)) {
+      if (time_manager.is_time_for_status_check(now_ms)) {
         robot.perform_status_check(now_ms);
       }
 
-      if (time_manager.isTimeForAutomaticCommand(now_ms)) {
+      if (time_manager.is_time_for_automatic_command(now_ms)) {
         robot.perform_automatic_action(now_ms);
       }
     }

--- a/test/control/test_time_manager/test_time_manager.cpp
+++ b/test/control/test_time_manager/test_time_manager.cpp
@@ -11,31 +11,31 @@ void tearDown(void) {
     // clean stuff up here
 }
 
-void testStatusCheckTrue(void) {
+void test_status_check_true(void) {
     TimeManager time_manager;
 
     // first pass should always return true
-    TEST_ASSERT_TRUE(time_manager.isTimeForStatusCheck(0));
+    TEST_ASSERT_TRUE(time_manager.is_time_for_status_check(0));
 
     const unsigned long TIME_FOR_STATUS = 1001;
-    TEST_ASSERT_TRUE(time_manager.isTimeForStatusCheck(TIME_FOR_STATUS));
+    TEST_ASSERT_TRUE(time_manager.is_time_for_status_check(TIME_FOR_STATUS));
 }
 
-void testStatusCheckFalse(void) {
+void test_status_check_false(void) {
     TimeManager time_manager;
 
     // first pass should always return true
-    time_manager.isTimeForStatusCheck(0);
+    time_manager.is_time_for_status_check(0);
 
     const unsigned long NOT_TIME_FOR_STATUS = 100;
-    TEST_ASSERT_FALSE(time_manager.isTimeForStatusCheck(NOT_TIME_FOR_STATUS));
+    TEST_ASSERT_FALSE(time_manager.is_time_for_status_check(NOT_TIME_FOR_STATUS));
 }
 
 int main( int argc, char **argv) {
     UNITY_BEGIN();
-   
-    RUN_TEST(testStatusCheckTrue);
-    RUN_TEST(testStatusCheckFalse);
+
+    RUN_TEST(test_status_check_true);
+    RUN_TEST(test_status_check_false);
 
     UNITY_END();
 
@@ -43,8 +43,5 @@ int main( int argc, char **argv) {
     cli();
     sleep_cpu();
 
-    return 0; 
+    return 0;
 }
-
-
-


### PR DESCRIPTION
## Summary
- `TimeManager`, `Motion::old_servo`, and `ArduinoRobotIndicators` used camelCase (`isTimeForStatusCheck`, `lastStatusMillis`, `oldServo`, `setLED`, `isValidLED`, `toggleBatteryLED`, etc.) while the rest of the codebase (`Sensing`, `AutoSteering`, `Regulator`, `ExternalCommandDecoder`, ...) uses snake_case. Renamed all of these to snake_case.
- Also renamed `TimeManager`'s `currentMillis` parameters to `current_millis` to match `Sensing`/`Robot`, and the `test_time_manager` test function names to match the snake_case convention used by every other test suite.

Fixes #30.

## Test plan
- [x] Verified `TimeManager` still behaves correctly by compiling `test/control/test_time_manager/test_time_manager.cpp` against a host stub of Unity/AVR headers and running it (2/2 tests pass).
- [x] Confirmed no remaining references to the old camelCase identifiers anywhere in the repo.
- [x] CI (`pio run` / `pio test` / `pio check`) — will confirm once it runs on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_