### PR TITLE
Give Robot an explicit AUTOMATIC/MANUAL state instead of re-reading a command flag

### DIFF
--- a/lib/Robot/Robot.h
+++ b/lib/Robot/Robot.h
@@ -14,6 +14,13 @@
 #include "UltraSoundSensor.h"
 
 /**
+ * Robot's own operating mode - AUTOMATIC follows/avoids walls, MANUAL only
+ * responds to direct speed/steering commands. See RobotCommand for the
+ * decoded external command that toggles it.
+ */
+enum class RobotState { MANUAL, AUTOMATIC };
+
+/**
  * Class representing the robot. It encapsulates sensing, motion and automatic
  * operation
  */
@@ -26,6 +33,7 @@ class Robot {
   ExternalCommandDecoder &external_command_decoder;
 
   RobotCommand robot_command;
+  RobotState robot_state = RobotState::AUTOMATIC;
 
   IRobotIndicators &robot_indicators;
 
@@ -76,10 +84,7 @@ public:
     auto desired_servo_angle =
         wall_following_steering.get_steering_command(distance_measurements);
 
-    // TODO: don't check the command, instead introduce robot state field that
-    // is set to AUTOMATIC or MANUAL based on external command, and check it
-    // here.
-    if (robot_command.enable_automatic_operation) {
+    if (robot_state == RobotState::AUTOMATIC) {
       robot_command.desired_servo_angle = desired_servo_angle;
 
       auto steering_state = wall_following_steering.get_steering_state();
@@ -96,10 +101,13 @@ public:
 
   /**
    * Check if there is a new external command from user and if so, convert it
-   * into RobotCommand instance
+   * into RobotCommand instance, updating robot_state to match
    */
   void check_external_command() {
     external_command_decoder.check_external_command(robot_command);
+    robot_state = robot_command.enable_automatic_operation
+                      ? RobotState::AUTOMATIC
+                      : RobotState::MANUAL;
   }
 
   void apply_motion_command() {


### PR DESCRIPTION
## Summary
- `Robot::perform_automatic_action` checked `robot_command.enable_automatic_operation` directly, per a pre-existing TODO asking for `Robot` to own its own explicit state instead of re-reading a command flag.
- Added a `RobotState` enum (`MANUAL`/`AUTOMATIC`), mirroring the existing `SteeringState` pattern already used by `AutoSteering`.
- `Robot::check_external_command()` now syncs `robot_state` from the decoded command right after decoding it, and `perform_automatic_action` checks `robot_state` instead of the raw command flag.
- `RobotCommand.enable_automatic_operation` and `ExternalCommandDecoder` are unchanged — the toggle command (`RIGHT_CIRCLE`) still flows through them the same way; `Robot` just no longer branches on that field directly.

Fixes #33.

## Test plan
- [x] Wired `Sensing`/`Battery`/`Motion`/`Robot`/`ExternalCommandDecoder`/`OvladackaParser` together with mock hardware interfaces on the host and fed a real `:f!` (RIGHT_CIRCLE) command through the decoder end to end — confirmed the robot starts `AUTOMATIC` (indicates robot state every cycle), and after the toggle command switches to `MANUAL` (stops indicating robot state), matching the pre-existing behavior's semantics exactly.
- [ ] CI (`pio run` / `pio test` / `pio check`) — will confirm once it runs on this PR; PlatformIO's AVR toolchain isn't reachable from this environment so full on-target compilation couldn't be verified locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_