### PR TITLE
Enforce clang-format 22 in CI via ubuntu-26.04 + explicit pip install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -28,3 +28,14 @@ jobs:
 
       - name: Run static code analysis
         run: pio check --skip-packages
+
+      - name: Install clang-format
+        run: pip install clang-format==22.1.5
+
+      - name: Check code formatting
+        # Informational only for now: most of the codebase doesn't conform
+        # to .clang-format yet, so this doesn't fail the build.
+        continue-on-error: true
+        run: |
+          find lib src test -regextype posix-extended -regex '.*\.(cpp|h)$' -print0 \
+            | xargs -0 clang-format --dry-run -Werror


### PR DESCRIPTION
## Summary
- `.clang-format` needs clang-format 22 to parse (see #29). Ubuntu 26.04's `apt` package is only 21.1.6, which I verified still fails to parse the config (same `unknown key 'AlignPPAndNotPP'` error as v20, plus ~10 more incompatible keys) — so switching the runner alone wasn't enough.
- Switch CI to `runs-on: ubuntu-26.04`, and install clang-format **22.1.5 explicitly via pip** (verified this ships a real, working prebuilt binary — confirmed it parses `.clang-format` cleanly) rather than relying on the distro package.
- Add a "Check code formatting" step running `clang-format --dry-run -Werror` across `lib/`, `src/`, `test/`.
- **The check runs with `continue-on-error: true` for now** — I measured that 29 of 52 (~56%) of the codebase's `.cpp`/`.h` files don't currently conform to `.clang-format`, so a hard gate would fail every PR immediately. This makes formatting visible in CI (shown as a warning, not a failure) without blocking merges until the codebase is reformatted separately.

Progresses #29 (doesn't close it — the codebase still needs to actually be reformatted to flip this to blocking).

## Test plan
- [x] Verified locally with the real clang-format 22.1.5 binary (installed via the same `pip install clang-format==22.1.5` this PR adds to CI) that `.clang-format` parses cleanly and the exact `find | xargs clang-format --dry-run -Werror` command in the workflow runs as expected (exit 123, 29/52 files flagged, matching what's described above).
- [x] CI — will confirm the `ubuntu-26.04` runner and the new steps actually work once this PR's own CI run completes; I can't run GitHub-hosted `ubuntu-26.04` runners from this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_