### PR TITLE
Add PORTING.md documenting the hardware abstraction boundary

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -1,26 +1,34 @@
-# Porting wallckr to new hardware
+# Porting wallckr to a new target
 
 This document describes the hardware abstraction boundary in this codebase,
-for anyone porting wallckr's firmware to different hardware (for example a
-V2 robot on different MCU/RTOS, such as Zephyr). It reflects the current
-Arduino/PlatformIO V1 architecture, not a promise about how a ported V2
-codebase will be organized.
+for anyone porting wallckr's firmware to a new target - different hardware, a
+different framework/RTOS on the *same* hardware (e.g. moving to Zephyr), or
+both at once, as planned for a V2 robot. It reflects the current
+Arduino/PlatformIO V1 architecture, not a promise about how a ported codebase
+will be organized.
 
-## The short version
+## TL;DR
+
+Implement `IMotorController`, `ISteeringServo`, `IBatterySensor`,
+`IDistanceSensor`, `IRobotIndicators`, and `IRobotIOStream` for your target,
+write your own entry point (like `src/main.cpp`) that wires them into
+`Robot`, and reuse everything else in `lib/` unchanged.
+
+## The longer version
 
 Every `lib/` folder is either:
 
-- **hardware-independent** - plain C++, no Arduino/AVR types, unit tested on
+- **target-independent** - plain C++, no Arduino/AVR types, unit tested on
   the host (see [Testing](#testing) below), or
-- **hardware-specific** - implements one of a small set of interfaces using
+- **target-specific** - implements one of a small set of interfaces using
   Arduino APIs, named `<Something>Arduino`.
 
-A port needs to replace every hardware-specific folder with an equivalent
-implementing the same interface for the new hardware. Everything else -
+A port needs to replace every target-specific folder with an equivalent
+implementing the same interface for the new target. Everything else -
 control logic, protocol decoding, the `Robot` state machine - is meant to be
 reused unchanged.
 
-## Hardware-independent (reuse as-is)
+## Target-independent (reuse as-is)
 
 | Folder | What it is |
 | --- | --- |
@@ -33,7 +41,7 @@ reused unchanged.
 | `lib/Robot` | `Robot` - the top-level state machine (AUTOMATIC/MANUAL, battery-triggered safety disable) |
 | `lib/Motion` | `Motion`, plus the `IMotorController`/`ISteeringServo` interfaces (the concrete Arduino implementations live in `lib/MotionArduino`) |
 
-## Hardware-specific (reimplement per-target)
+## Target-specific (reimplement per-target)
 
 | Folder | Implements | Needs |
 | --- | --- | --- |
@@ -43,10 +51,10 @@ reused unchanged.
 | `lib/CommunicationArduino` | `IRobotIndicators`, plus `IRobotIOStream` for the BLE UART | `<Arduino.h>` |
 | `lib/BoardConfig` | Pin assignments (`ArduinoBoardConfig.h`) | `<Arduino.h>` |
 
-A port implements these five interfaces - `IMotorController`, `ISteeringServo`,
+A port implements these six interfaces - `IMotorController`, `ISteeringServo`,
 `IBatterySensor`, `IDistanceSensor`, `IRobotIndicators`, and `IRobotIOStream`
 (used both for the BLE command stream and for outgoing telemetry) - for the
-new hardware, and writes a new entry point (like `src/main.cpp`) that wires
+new target, and writes a new entry point (like `src/main.cpp`) that wires
 them into `Robot` the same way `src/main.cpp` does today.
 
 ## Testing
@@ -55,26 +63,39 @@ The `native` PlatformIO environment (`platformio.ini`) builds and runs every
 test suite directly on the host compiler, with no AVR toolchain, no simavr,
 and nothing from the `*Arduino`/`BoardConfig` folders involved. If a test
 fails to build there, something it depends on isn't actually
-hardware-independent yet - that env exists specifically to catch this class
-of coupling before it becomes a porting surprise (see PR #41 and PR #42 for
-two examples this already caught: implementation files that were sharing a
-library folder with hardware-independent headers, and a stray transitive
+target-independent yet - that env exists specifically to catch this class of
+coupling before it becomes a porting surprise (see PR #41 and PR #42 for two
+examples this already caught: implementation files that were sharing a
+library folder with target-independent headers, and a stray transitive
 include).
 
 wallckr's tests use the Unity framework via PlatformIO's test runner. A
-Zephyr-based V2 build (running under plain `west`, not PlatformIO) would most
+Zephyr-based build (running under plain `west`, not PlatformIO) would most
 naturally use Zephyr's own Ztest + Twister instead - the two frameworks'
 assert macros translate almost mechanically, but their test-registration
 models differ enough (manual `RUN_TEST()` calls vs. auto-discovered
 `ZTEST()`) that porting a test file is expected to mean rewriting it against
 Ztest, not sharing one file between both frameworks.
 
-## Known wrinkle: calibration constants live in "portable" files
+## Known wrinkles
 
-`lib/Motion/MotionConstants.h` (`SERVO_MIN_RIGHT`, `SERVO_MAX_LEFT`,
-`SERVO_CENTER`, `MAX_SPEED`, ...) is hardware-independent code, but its
-values are calibrated for V1's specific servo and motor. A straight copy for
-a V2 port will build and pass tests, but the numbers themselves will need
-re-tuning for the new hardware. Same for the battery cell count/cutoff
-constants in `src/main.cpp`. Neither is broken - just worth knowing they're
-V1-specific values sitting in otherwise-reusable files.
+**Calibration constants live in "portable" files.** `lib/Motion/MotionConstants.h`
+(`SERVO_MIN_RIGHT`, `SERVO_MAX_LEFT`, `SERVO_CENTER`, `MAX_SPEED`, ...) is
+target-independent code, but its values are calibrated for V1's specific
+servo and motor. A straight copy for a new port will build and pass tests,
+but the numbers themselves will need re-tuning for the new hardware. Same
+for the battery cell count/cutoff constants in `src/main.cpp`. Neither is
+broken - just worth knowing they're V1-specific values sitting in
+otherwise-reusable files.
+
+**`TimeManager` is a bare-metal stand-in for scheduling.** `PollingRobotRunner`
+(`src/PollingRobotRunner.h`) drives `Robot` from a plain `while(true)` super
+loop, using `TimeManager` to manually check elapsed milliseconds and decide
+when it's time to run the next status check or automatic-control cycle -
+because that loop has no real scheduler underneath it. On an RTOS like
+Zephyr, that job is more naturally done with periodic threads, timers, or
+work queues, so `TimeManager` and the polling pattern in
+`PollingRobotRunner` are likely not worth porting - a Zephyr entry point
+would probably call `robot.perform_status_check()` /
+`robot.perform_automatic_action()` from timer callbacks or dedicated threads
+at the right periods instead.

--- a/PORTING.md
+++ b/PORTING.md
@@ -1,0 +1,80 @@
+# Porting wallckr to new hardware
+
+This document describes the hardware abstraction boundary in this codebase,
+for anyone porting wallckr's firmware to different hardware (for example a
+V2 robot on different MCU/RTOS, such as Zephyr). It reflects the current
+Arduino/PlatformIO V1 architecture, not a promise about how a ported V2
+codebase will be organized.
+
+## The short version
+
+Every `lib/` folder is either:
+
+- **hardware-independent** - plain C++, no Arduino/AVR types, unit tested on
+  the host (see [Testing](#testing) below), or
+- **hardware-specific** - implements one of a small set of interfaces using
+  Arduino APIs, named `<Something>Arduino`.
+
+A port needs to replace every hardware-specific folder with an equivalent
+implementing the same interface for the new hardware. Everything else -
+control logic, protocol decoding, the `Robot` state machine - is meant to be
+reused unchanged.
+
+## Hardware-independent (reuse as-is)
+
+| Folder | What it is |
+| --- | --- |
+| `lib/Control` | `Regulator`/`Regulator_P`/`Regulator_PD`, `AutoSteering` (FOLLOWING/AVOIDING state machine), `ExpFilter`, `TimeManager`, `RobotCommand` |
+| `lib/Battery` | `Battery` health/cutoff-with-hysteresis logic, `IBatterySensor` interface |
+| `lib/Sensing` | `Sensing` (aggregates distance measurements, sends telemetry), `IDistanceSensor` interface |
+| `lib/Communication` | `ExternalCommandDecoder`, `OvladackaParser`/`BLEJoystickDecoder` protocol decoders, `IRobotIndicators` interface |
+| `lib/Telemetry` | `RobotPackets` (wire format), `RobotPrinter` |
+| `lib/IOStream` | `IRobotIOStream` interface |
+| `lib/Robot` | `Robot` - the top-level state machine (AUTOMATIC/MANUAL, battery-triggered safety disable) |
+| `lib/Motion` | `Motion`, plus the `IMotorController`/`ISteeringServo` interfaces (the concrete Arduino implementations live in `lib/MotionArduino`) |
+
+## Hardware-specific (reimplement per-target)
+
+| Folder | Implements | Needs |
+| --- | --- | --- |
+| `lib/MotionArduino` | `IMotorController`, `ISteeringServo` | `<Arduino.h>`, `<Servo.h>` |
+| `lib/BatteryArduino` | `IBatterySensor` | `<Arduino.h>` (ADC read) |
+| `lib/SensingArduino` | `IDistanceSensor` | `<NewPing.h>` |
+| `lib/CommunicationArduino` | `IRobotIndicators`, plus `IRobotIOStream` for the BLE UART | `<Arduino.h>` |
+| `lib/BoardConfig` | Pin assignments (`ArduinoBoardConfig.h`) | `<Arduino.h>` |
+
+A port implements these five interfaces - `IMotorController`, `ISteeringServo`,
+`IBatterySensor`, `IDistanceSensor`, `IRobotIndicators`, and `IRobotIOStream`
+(used both for the BLE command stream and for outgoing telemetry) - for the
+new hardware, and writes a new entry point (like `src/main.cpp`) that wires
+them into `Robot` the same way `src/main.cpp` does today.
+
+## Testing
+
+The `native` PlatformIO environment (`platformio.ini`) builds and runs every
+test suite directly on the host compiler, with no AVR toolchain, no simavr,
+and nothing from the `*Arduino`/`BoardConfig` folders involved. If a test
+fails to build there, something it depends on isn't actually
+hardware-independent yet - that env exists specifically to catch this class
+of coupling before it becomes a porting surprise (see PR #41 and PR #42 for
+two examples this already caught: implementation files that were sharing a
+library folder with hardware-independent headers, and a stray transitive
+include).
+
+wallckr's tests use the Unity framework via PlatformIO's test runner. A
+Zephyr-based V2 build (running under plain `west`, not PlatformIO) would most
+naturally use Zephyr's own Ztest + Twister instead - the two frameworks'
+assert macros translate almost mechanically, but their test-registration
+models differ enough (manual `RUN_TEST()` calls vs. auto-discovered
+`ZTEST()`) that porting a test file is expected to mean rewriting it against
+Ztest, not sharing one file between both frameworks.
+
+## Known wrinkle: calibration constants live in "portable" files
+
+`lib/Motion/MotionConstants.h` (`SERVO_MIN_RIGHT`, `SERVO_MAX_LEFT`,
+`SERVO_CENTER`, `MAX_SPEED`, ...) is hardware-independent code, but its
+values are calibrated for V1's specific servo and motor. A straight copy for
+a V2 port will build and pass tests, but the numbers themselves will need
+re-tuning for the new hardware. Same for the battery cell count/cutoff
+constants in `src/main.cpp`. Neither is broken - just worth knowing they're
+V1-specific values sitting in otherwise-reusable files.

--- a/README.md
+++ b/README.md
@@ -96,5 +96,8 @@ You can disable/enable this automatic steering via ovladacka (press `left shift`
 ## Contributing
 In case you would like to fix or improve anything, feel free to create a pull request. 
 
+## Porting
+Looking to run this on different hardware? See [PORTING.md](PORTING.md) for the hardware abstraction boundary.
+
 ## License
 This project is licensed under the MIT license. Why? Because I wanted a permissive license that would give anybody a chance to do with this code whatever they please. Of course, with no warranty :) 


### PR DESCRIPTION
## Summary

- Adds `PORTING.md`, written ahead of the planned V2 port (different hardware, running plain Zephyr/`west` instead of PlatformIO).
- Documents which `lib/` folders are hardware-independent and meant to be reused as-is (`Control`, `Battery`, `Sensing`, `Communication`, `Telemetry`, `IOStream`, `Robot`, `Motion`) versus which implement the HAL interfaces and need a per-target reimplementation (`MotionArduino`, `BatteryArduino`, `SensingArduino`, `CommunicationArduino`, `BoardConfig`).
- Explains what the `native` PlatformIO test env (added in #41) is actually for, citing the two coupling bugs it already caught (#41, #42) as concrete examples.
- Notes that a Zephyr-based V2 would most naturally use Ztest/Twister rather than sharing Unity test files - the assert macros translate mechanically but the registration model doesn't.
- Flags a known wrinkle: some V1-specific calibration constants (servo limits in `MotionConstants.h`, battery cutoff in `main.cpp`) currently live in otherwise-portable files and will need re-tuning, not just recompiling, for new hardware.
- Links to it from the README under a new "Porting" section.

This is documentation only - no behavioral changes, so nothing to verify beyond markdown rendering.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_