### PR TITLE
Make Regulator action limits constructor parameters

### DIFF
--- a/lib/Control/Regulator.h
+++ b/lib/Control/Regulator.h
@@ -13,9 +13,8 @@ protected:
   T m_setpoint;
   T m_insensitivity;
 
-  // TODO this should be also an input
-  const T m_action_limit_up = 45;
-  const T m_action_limit_bottom = -30;
+  T m_action_limit_up;
+  T m_action_limit_bottom;
 
   /**
    * Internal equation specific for each regulator type
@@ -32,9 +31,15 @@ public:
    * @param[in] setpoint required value - the goal of the regulated quantity
    * @param[in] insen regulator insensitivity - if difference between required
    * and actual value is lower than insensitivity, it is considered zero
+   * @param[in] action_limit_up upper clamp applied to the regulator action
+   * @param[in] action_limit_bottom lower clamp applied to the regulator
+   * action
    */
-  Regulator(T gain, T setpoint, T insen)
-      : m_gain(gain), m_setpoint(setpoint), m_insensitivity(insen) {};
+  Regulator(T gain, T setpoint, T insen, T action_limit_up,
+            T action_limit_bottom)
+      : m_gain(gain), m_setpoint(setpoint), m_insensitivity(insen),
+        m_action_limit_up(action_limit_up),
+        m_action_limit_bottom(action_limit_bottom) {};
   /**
    * Perform regulator action
    * @param[in] in current value of regulated quantity
@@ -79,9 +84,14 @@ public:
    * @param[in] setpoint required value - the goal of the regulated quantity
    * @param[in] insen regulator insensitivity - if difference between required
    * and actual value is lower than insensitivity, it is considered zero
+   * @param[in] action_limit_up upper clamp applied to the regulator action
+   * @param[in] action_limit_bottom lower clamp applied to the regulator
+   * action
    */
-  Regulator_P(T gain, T setpoint, T insen)
-      : Regulator<T>(gain, setpoint, insen) {};
+  Regulator_P(T gain, T setpoint, T insen, T action_limit_up,
+              T action_limit_bottom)
+      : Regulator<T>(gain, setpoint, insen, action_limit_up,
+                     action_limit_bottom) {};
 };
 
 /**
@@ -118,10 +128,15 @@ public:
    * @param[in] setpoint required value - the goal of the regulated quantity
    * @param[in] insen regulator insensitivity - if difference between required
    * and actual value is lower than insensitivity, it is considered zero
+   * @param[in] action_limit_up upper clamp applied to the regulator action
+   * @param[in] action_limit_bottom lower clamp applied to the regulator
+   * action
    */
-  Regulator_PD(T gain, T D_gain, T setpoint, T insen)
-      : Regulator<T>(gain, setpoint, insen), m_D_gain(D_gain),
-        m_first_run(true), m_last_e(0) {};
+  Regulator_PD(T gain, T D_gain, T setpoint, T insen, T action_limit_up,
+               T action_limit_bottom)
+      : Regulator<T>(gain, setpoint, insen, action_limit_up,
+                     action_limit_bottom),
+        m_D_gain(D_gain), m_first_run(true), m_last_e(0) {};
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,8 +64,11 @@ void loop() {
   const int K_GAIN = 5;
   const int RIGHT_DISTANCE_SETPOINT_CM = 25;
   const int INSENSITIV_CM = 2;
-  Regulator_P<int> side_distance_regulator(K_GAIN, RIGHT_DISTANCE_SETPOINT_CM,
-                                           INSENSITIV_CM);
+  const int REGULATOR_ACTION_LIMIT_UP = 45;
+  const int REGULATOR_ACTION_LIMIT_BOTTOM = -30;
+  Regulator_P<int> side_distance_regulator(
+      K_GAIN, RIGHT_DISTANCE_SETPOINT_CM, INSENSITIV_CM,
+      REGULATOR_ACTION_LIMIT_UP, REGULATOR_ACTION_LIMIT_BOTTOM);
   ArduinoRobotIndicators robot_indicators;
   AutoSteering<int> wall_following_steering(
       RIGHT_DISTANCE_SETPOINT_CM, side_distance_regulator, servo_cmd_filter);

--- a/test/control/test_auto_steering/test_auto_steering.cpp
+++ b/test/control/test_auto_steering/test_auto_steering.cpp
@@ -11,7 +11,9 @@ protected:
   int regulator_equation(int e) override { return e; }
 
 public:
-  IdentityRegulator() : Regulator<int>(1, 0, 0) {}
+  // Action limits mirror Regulator's old hardcoded defaults - irrelevant to
+  // what this test double is standing in for here.
+  IdentityRegulator() : Regulator<int>(1, 0, 0, 45, -30) {}
 };
 
 class IdentityFilter : public IFilter<int> {

--- a/test/control/test_regulator/test_regulator.cpp
+++ b/test/control/test_regulator/test_regulator.cpp
@@ -5,6 +5,8 @@
 namespace {
 const int SETPOINT_CM = 25;
 const int INSENSITIVITY_CM = 2;
+const int ACTION_LIMIT_UP = 45;
+const int ACTION_LIMIT_BOTTOM = -30;
 } // namespace
 
 void setUp(void) {
@@ -17,7 +19,8 @@ void tearDown(void) {
 
 void test_p_regulator_within_insensitivity_band_is_zero(void) {
   const int GAIN = 5;
-  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                             ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   TEST_ASSERT_EQUAL(
       0, regulator.action(SETPOINT_CM - 1)); // e = 1, within insensitivity
@@ -26,16 +29,16 @@ void test_p_regulator_within_insensitivity_band_is_zero(void) {
 void test_p_regulator_applies_gain(void) {
   const int GAIN = 5;
   const int ERROR_CM = 5;
-  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                             ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   TEST_ASSERT_EQUAL(GAIN * ERROR_CM, regulator.action(SETPOINT_CM - ERROR_CM));
 }
 
 void test_p_regulator_clamps_to_upper_limit(void) {
   const int GAIN = 10;
-  const int ACTION_LIMIT_UP =
-      45; // mirrors Regulator's internal m_action_limit_up
-  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                             ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   TEST_ASSERT_EQUAL(ACTION_LIMIT_UP,
                     regulator.action(0)); // e = 25, raw out = 250
@@ -43,11 +46,26 @@ void test_p_regulator_clamps_to_upper_limit(void) {
 
 void test_p_regulator_clamps_to_lower_limit(void) {
   const int GAIN = 10;
-  const int ACTION_LIMIT_BOTTOM =
-      -30; // mirrors Regulator's internal m_action_limit_bottom
-  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                             ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   TEST_ASSERT_EQUAL(ACTION_LIMIT_BOTTOM,
+                    regulator.action(50)); // e = -25, raw out = -250
+}
+
+void test_p_regulator_clamps_to_custom_action_limits(void) {
+  const int GAIN = 10;
+  // Deliberately different from ACTION_LIMIT_UP/ACTION_LIMIT_BOTTOM above, to
+  // prove the limits are actually per-instance rather than hardcoded.
+  const int CUSTOM_ACTION_LIMIT_UP = 20;
+  const int CUSTOM_ACTION_LIMIT_BOTTOM = -15;
+  Regulator_P<int> regulator(GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                             CUSTOM_ACTION_LIMIT_UP,
+                             CUSTOM_ACTION_LIMIT_BOTTOM);
+
+  TEST_ASSERT_EQUAL(CUSTOM_ACTION_LIMIT_UP,
+                    regulator.action(0)); // e = 25, raw out = 250
+  TEST_ASSERT_EQUAL(CUSTOM_ACTION_LIMIT_BOTTOM,
                     regulator.action(50)); // e = -25, raw out = -250
 }
 
@@ -55,7 +73,8 @@ void test_pd_regulator_first_action_ignores_derivative(void) {
   const int GAIN = 2;
   const int D_GAIN = 3;
   const int ERROR_CM = 5;
-  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                              ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   TEST_ASSERT_EQUAL(GAIN * ERROR_CM, regulator.action(SETPOINT_CM - ERROR_CM));
 }
@@ -65,7 +84,8 @@ void test_pd_regulator_adds_derivative_term_on_subsequent_action(void) {
   const int D_GAIN = 3;
   const int FIRST_ERROR_CM = 5;
   const int SECOND_ERROR_CM = 10;
-  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                              ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   regulator.action(
       SETPOINT_CM -
@@ -80,7 +100,8 @@ void test_pd_regulator_keeps_last_error_across_insensitivity_band(void) {
   const int D_GAIN = 1;
   const int FIRST_ERROR_CM = 5;
   const int THIRD_ERROR_CM = 6;
-  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM);
+  Regulator_PD<int> regulator(GAIN, D_GAIN, SETPOINT_CM, INSENSITIVITY_CM,
+                              ACTION_LIMIT_UP, ACTION_LIMIT_BOTTOM);
 
   regulator.action(
       SETPOINT_CM -
@@ -101,6 +122,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_p_regulator_applies_gain);
   RUN_TEST(test_p_regulator_clamps_to_upper_limit);
   RUN_TEST(test_p_regulator_clamps_to_lower_limit);
+  RUN_TEST(test_p_regulator_clamps_to_custom_action_limits);
 
   RUN_TEST(test_pd_regulator_first_action_ignores_derivative);
   RUN_TEST(test_pd_regulator_adds_derivative_term_on_subsequent_action);

--- a/test/robot/test_robot/test_robot.cpp
+++ b/test/robot/test_robot/test_robot.cpp
@@ -82,7 +82,9 @@ protected:
   int regulator_equation(int e) override { return e; }
 
 public:
-  IdentityRegulator() : Regulator<int>(1, 0, 0) {}
+  // Action limits mirror Regulator's old hardcoded defaults - irrelevant to
+  // what this test double is standing in for here.
+  IdentityRegulator() : Regulator<int>(1, 0, 0, 45, -30) {}
 };
 
 class IdentityFilter : public IFilter<int> {


### PR DESCRIPTION
## Summary

Closes #35.

- `Regulator`'s clamp limits (`m_action_limit_up`/`m_action_limit_bottom`) were hardcoded to `45`/`-30`, unlike `gain`/`setpoint`/`insensitivity` which were already constructor parameters. Adds `action_limit_up`/`action_limit_bottom` as required constructor parameters on `Regulator`, `Regulator_P`, and `Regulator_PD`, forwarded the same way `D_gain` already is.
- `src/main.cpp` now passes `45`/`-30` explicitly as named constants (`REGULATOR_ACTION_LIMIT_UP`/`REGULATOR_ACTION_LIMIT_BOTTOM`) alongside the robot's other tuning parameters, preserving current behavior.
- The `IdentityRegulator` test doubles in `test_auto_steering.cpp` and `test_robot.cpp` also pass `45`/`-30` explicitly, since their exact values don't matter to those tests.
- `test_regulator.cpp` keeps its existing clamp assertions against the old default values, and gets a new test (`test_p_regulator_clamps_to_custom_action_limits`) constructing a `Regulator_P` with different limits (`20`/`-15`) to actually prove the clamps are per-instance now, not just refactored in place.

## Test plan

- [x] Compiled and ran `test_regulator`, `test_auto_steering`, and `test_robot` with host g++ (mirroring the `native` env) - 19/19 tests pass.
- [x] `clang-format --dry-run -Werror` clean on all changed files.
- [ ] CI: AVR/simavr + native `pio test`, static analysis, clang-format check (this sandbox has no PlatformIO registry access).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_