### PR TITLE
Fix minor cppcheck findings

### DIFF
--- a/lib/MotionArduino/ArduinoMotorController.h
+++ b/lib/MotionArduino/ArduinoMotorController.h
@@ -11,8 +11,8 @@ class ArduinoMotorController : public IMotorController {
 public:
   ArduinoMotorController(int dir_pin, int pwm_control_pin,
                          int break_control_pin);
-  bool set_speed(int speed);
-  void stop();
+  bool set_speed(int speed) override;
+  void stop() override;
 };
 
 #endif // ARDUINO_MOTOR_CONTROLLER_H

--- a/lib/MotionArduino/ArduinoSteeringServo.h
+++ b/lib/MotionArduino/ArduinoSteeringServo.h
@@ -9,7 +9,7 @@ class ArduinoSteeringServo : public ISteeringServo {
 
 public:
   explicit ArduinoSteeringServo(int pin);
-  bool set_angle(int angle);
+  bool set_angle(int angle) override;
 };
 
 #endif // STEERING_SERVO_H

--- a/src/PollingRobotRunner.h
+++ b/src/PollingRobotRunner.h
@@ -9,7 +9,7 @@ class PollingRobotRunner {
   TimeManager time_manager;
 
 public:
-  PollingRobotRunner(Robot &robot) : robot(robot) {}
+  explicit PollingRobotRunner(Robot &robot) : robot(robot) {}
   void run_once(uint32_t now_ms) {
     robot.check_external_command();
     robot.apply_motion_command();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "UltraSoundSensor.h"
 #include <Arduino.h>
 
+// cppcheck-suppress unusedFunction ; called by the Arduino core's own main()
 void setup() {
   // Initialize serial communication representing wired UART over USB connection
   Serial.begin(115200);
@@ -24,6 +25,7 @@ void setup() {
   Serial3.write("AT NAMEwallckr\r\n");
 }
 
+// cppcheck-suppress unusedFunction ; called by the Arduino core's own main()
 void loop() {
 
   ArduinoSerialStream arduino_serial_stream(Serial3);


### PR DESCRIPTION
## Summary

`pio check` has been passing CI (it doesn't fail the build on findings), but the latest run still reported 6 low-severity cppcheck warnings worth cleaning up:

```
src/PollingRobotRunner.h:12: [low:style] Class 'PollingRobotRunner' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
lib/MotionArduino/ArduinoMotorController.h:14: [low:style] The function 'set_speed' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
lib/MotionArduino/ArduinoMotorController.h:15: [low:style] The function 'stop' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
lib/MotionArduino/ArduinoSteeringServo.h:12: [low:style] The function 'set_angle' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
src/main.cpp:14: [low:style] The function 'setup' is never used. [unusedFunction]
src/main.cpp:27: [low:style] The function 'loop' is never used. [unusedFunction]
```

- Marked `PollingRobotRunner`'s single-argument constructor `explicit`, matching the convention already used elsewhere (`ExternalCommandDecoder`, `RobotPrinter`, `ArduinoSteeringServo`).
- Added the missing `override` specifier to `ArduinoMotorController::set_speed`/`stop` and `ArduinoSteeringServo::set_angle` - all three implement virtual interface methods.
- Suppressed the `unusedFunction` warning on `setup()`/`loop()` in `main.cpp` with `// cppcheck-suppress unusedFunction`. These are called by the Arduino core's own `main()`, invisible to cppcheck, so this is an expected false positive on every Arduino sketch rather than a real issue - leaving it unsuppressed would just be permanent noise in every future `pio check` run.

## Test plan

- [x] Syntax-checked `PollingRobotRunner.h` with host g++ (the `Arduino*` header changes can't be host-compiled since they need real Arduino/Servo headers, but the changes are additive `override`/`explicit` keywords that exactly match the existing `.cpp` definitions).
- [x] Re-ran `test_robot` (host g++) to confirm nothing else regressed - 5/5 pass.
- [x] `clang-format --dry-run -Werror` clean on all changed files.
- [ ] CI: `pio check` should now report 0 findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_