### PR TITLE
Move UltraSoundSensor's implementation out of the header

### DIFF
--- a/lib/SensingArduino/UltraSoundSensor.cpp
+++ b/lib/SensingArduino/UltraSoundSensor.cpp
@@ -1,0 +1,27 @@
+#include "UltraSoundSensor.h"
+
+bool UltraSoundSensor::trigger_measurement() {
+  m_measurement_raw_cm = m_sonar.ping_cm();
+
+  // Zero means out of range -> change the library, so I can distinguish
+  // actual zero and out of range?
+  if (m_measurement_raw_cm == 0) {
+    m_measurement_raw_cm = m_max_cm_distance;
+  }
+
+  return true;
+}
+
+unsigned long UltraSoundSensor::get_distance_raw_cm() {
+  trigger_measurement();
+
+  return m_measurement_raw_cm;
+}
+
+unsigned long UltraSoundSensor::get_distance_filtered_cm() {
+  trigger_measurement();
+
+  m_measurement_filtered_cm = m_sonar_filter.next(m_measurement_raw_cm);
+
+  return m_measurement_filtered_cm;
+}

--- a/lib/SensingArduino/UltraSoundSensor.h
+++ b/lib/SensingArduino/UltraSoundSensor.h
@@ -31,39 +31,19 @@ public:
    * Command sensor to measure distance
    * @return always true, reserved for future use
    */
-  bool trigger_measurement() override {
-    m_measurement_raw_cm = m_sonar.ping_cm();
-
-    // Zero means out of range -> change the library, so I can distinguish
-    // actual zero and out of range?
-    if (m_measurement_raw_cm == 0) {
-      m_measurement_raw_cm = m_max_cm_distance;
-    }
-
-    return true;
-  }
+  bool trigger_measurement() override;
 
   /**
    * Command sensor to measure distance and return unfiltered measurement
    * @return unfiltered distance measurement in cm
    */
-  unsigned long get_distance_raw_cm() override {
-    trigger_measurement();
-
-    return m_measurement_raw_cm;
-  }
+  unsigned long get_distance_raw_cm() override;
 
   /**
    * Command sensor to measure distance and return filtered measurement
    * @return filtered distance measurement in cm
    */
-  unsigned long get_distance_filtered_cm() override {
-    trigger_measurement();
-
-    m_measurement_filtered_cm = m_sonar_filter.next(m_measurement_raw_cm);
-
-    return m_measurement_filtered_cm;
-  }
+  unsigned long get_distance_filtered_cm() override;
 };
 
 #endif


### PR DESCRIPTION
## Summary

Found while auditing the project for empty files: `lib/SensingArduino/UltraSoundSensor.cpp` was completely empty. Turned out `UltraSoundSensor` was the only Arduino HAL class implementing its methods inline in the header instead of in its `.cpp` - every sibling (`ArduinoBatterySensor`, `ArduinoMotorController`, `ArduinoSteeringServo`, `ArduinoRobotIndicators`) declares in the header and implements in the `.cpp`. That's presumably how the `.cpp` ended up empty rather than deleted.

- Moved `trigger_measurement()`, `get_distance_raw_cm()`, and `get_distance_filtered_cm()` from `UltraSoundSensor.h` into `UltraSoundSensor.cpp`, matching the established pattern.
- No behavior change - pure declaration/definition split.

## Test plan

- [x] Compiled `UltraSoundSensor.cpp` standalone with host g++ against the existing `NewPing.h` test stub - clean.
- [x] `clang-format --dry-run -Werror` clean on both changed files.
- [ ] CI: AVR build, AVR/simavr + native tests, static analysis, clang-format check (this sandbox has no PlatformIO registry access; `UltraSoundSensor` isn't exercised by the native test env since nothing under test currently pulls in `lib/SensingArduino`, so the real signal here is the AVR "Build firmware" step).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_