### PR TITLE
Rename UltraSoundSensor to ArduinoUltraSoundSensor for consistency

### DIFF
--- a/lib/SensingArduino/ArduinoUltraSoundSensor.cpp
+++ b/lib/SensingArduino/ArduinoUltraSoundSensor.cpp
@@ -1,6 +1,6 @@
-#include "UltraSoundSensor.h"
+#include "ArduinoUltraSoundSensor.h"
 
-bool UltraSoundSensor::trigger_measurement() {
+bool ArduinoUltraSoundSensor::trigger_measurement() {
   m_measurement_raw_cm = m_sonar.ping_cm();
 
   // Zero means out of range -> change the library, so I can distinguish
@@ -12,13 +12,13 @@ bool UltraSoundSensor::trigger_measurement() {
   return true;
 }
 
-unsigned long UltraSoundSensor::get_distance_raw_cm() {
+unsigned long ArduinoUltraSoundSensor::get_distance_raw_cm() {
   trigger_measurement();
 
   return m_measurement_raw_cm;
 }
 
-unsigned long UltraSoundSensor::get_distance_filtered_cm() {
+unsigned long ArduinoUltraSoundSensor::get_distance_filtered_cm() {
   trigger_measurement();
 
   m_measurement_filtered_cm = m_sonar_filter.next(m_measurement_raw_cm);

--- a/lib/SensingArduino/ArduinoUltraSoundSensor.h
+++ b/lib/SensingArduino/ArduinoUltraSoundSensor.h
@@ -1,5 +1,5 @@
-#ifndef ULTRASOUNT_SENSOR_H
-#define ULTRASOUNT_SENSOR_H
+#ifndef ARDUINO_ULTRASOUND_SENSOR_H
+#define ARDUINO_ULTRASOUND_SENSOR_H
 
 #include "ExpFilter.h"
 #include "IDistanceSensor.h"
@@ -10,7 +10,7 @@ constexpr int MAX_DISTANCE_CM = 200;
 /**
  * Class representing ultrasound distance sensor, implements IDistanceSensor
  */
-class UltraSoundSensor : public IDistanceSensor {
+class ArduinoUltraSoundSensor : public IDistanceSensor {
   unsigned long m_measurement_raw_cm = 0;
   unsigned long m_measurement_filtered_cm = 0;
   unsigned int m_max_cm_distance;
@@ -22,8 +22,8 @@ class UltraSoundSensor : public IDistanceSensor {
   ExpFilter<int, FILTER_N> m_sonar_filter;
 
 public:
-  UltraSoundSensor(uint8_t trigger_pin, uint8_t echo_pin,
-                   unsigned int max_cm_distance)
+  ArduinoUltraSoundSensor(uint8_t trigger_pin, uint8_t echo_pin,
+                          unsigned int max_cm_distance)
       : m_max_cm_distance(max_cm_distance),
         m_sonar(trigger_pin, echo_pin, max_cm_distance) {};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,11 @@
 #include "ArduinoRobotIndicators.h"
 #include "ArduinoSerialStream.h"
 #include "ArduinoSteeringServo.h"
+#include "ArduinoUltraSoundSensor.h"
 #include "Battery.h"
 #include "PollingRobotRunner.h"
 #include "Robot.h"
 #include "RobotPrinter.h"
-#include "UltraSoundSensor.h"
 #include <Arduino.h>
 
 // cppcheck-suppress unusedFunction ; called by the Arduino core's own main()
@@ -31,12 +31,12 @@ void loop() {
 
   ArduinoSerialStream arduino_serial_stream(Serial3);
   RobotPrinter BLE_out(arduino_serial_stream);
-  UltraSoundSensor sonar_front(TRIGGER_PIN_FRONT, ECHO_PIN_FRONT,
-                               MAX_DISTANCE_CM);
-  UltraSoundSensor sonar_right_front(TRIGGER_PIN_RIGHT_FRONT,
-                                     ECHO_PIN_RIGHT_FRONT, MAX_DISTANCE_CM);
-  UltraSoundSensor sonar_right_center(TRIGGER_PIN_RIGHT_CENTER,
-                                      ECHO_PIN_RIGHT_CENTER, MAX_DISTANCE_CM);
+  ArduinoUltraSoundSensor sonar_front(TRIGGER_PIN_FRONT, ECHO_PIN_FRONT,
+                                      MAX_DISTANCE_CM);
+  ArduinoUltraSoundSensor sonar_right_front(
+      TRIGGER_PIN_RIGHT_FRONT, ECHO_PIN_RIGHT_FRONT, MAX_DISTANCE_CM);
+  ArduinoUltraSoundSensor sonar_right_center(
+      TRIGGER_PIN_RIGHT_CENTER, ECHO_PIN_RIGHT_CENTER, MAX_DISTANCE_CM);
   DistanceSensors distance_sensors = {sonar_front, sonar_right_front,
                                       sonar_right_center};
   Sensing robot_sensing(distance_sensors, BLE_out);


### PR DESCRIPTION
## Summary

Follow-up to #47. Every other Arduino HAL implementation in the codebase is prefixed with `Arduino` (`ArduinoBatterySensor`, `ArduinoCurrentSensor`, `ArduinoBoardConfig`, `ArduinoRobotIndicators`, `ArduinoSerialStream`, `ArduinoMotorController`, `ArduinoSteeringServo`) - `UltraSoundSensor` was the one exception, despite living in `lib/SensingArduino/` and being just as NewPing/Arduino-specific as the rest.

- Renamed the class and both files to `ArduinoUltraSoundSensor`.
- Fixed the header's include guard while touching it anyway (it was a pre-existing typo: `ULTRASOUNT_SENSOR_H` instead of `ULTRASOUND_SENSOR_H`).
- Updated the one production call site in `main.cpp`.
- No behavior change - pure rename.

## Test plan

- [x] Compiled `ArduinoUltraSoundSensor.cpp` standalone with host g++ against the existing `NewPing.h` test stub - clean.
- [x] `clang-format --dry-run -Werror` clean on all changed files.
- [x] CI: AVR build, AVR/simavr + native tests, static analysis, clang-format check (this sandbox has no PlatformIO registry access; the real signal here is the AVR "Build firmware" step in `main.cpp`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_