### PR TITLE
Remove the filter-injection TODO from ArduinoUltraSoundSensor.h

### DIFF
--- a/lib/SensingArduino/ArduinoUltraSoundSensor.h
+++ b/lib/SensingArduino/ArduinoUltraSoundSensor.h
@@ -16,8 +16,6 @@ class ArduinoUltraSoundSensor : public IDistanceSensor {
   unsigned int m_max_cm_distance;
 
   NewPing m_sonar;
-  // TODO Would be better to accept reference to base class of filter as
-  // constructor input
   static constexpr int FILTER_N = 4;
   ExpFilter<int, FILTER_N> m_sonar_filter;
 


### PR DESCRIPTION
## Summary

One of the three TODOs found while auditing the project for empty files/TODOs. Decided not to pursue it: there's exactly one filter type (`ExpFilter<int, 4>`) in use across all three sensor instances, nothing needs to swap it, and `ArduinoUltraSoundSensor` already sits fully inside the Arduino-specific boundary, so it doesn't carry the porting-related pressure that motivated dependency injection elsewhere (`Motion`, `Battery`, `Sensing`). Injecting it would mean a new constructor param and three externally-owned filter objects in `main.cpp` for flexibility nobody needs.

- Removed the comment rather than leave it lingering as a "would be nice" note we've consciously decided against.
- No behavior change.

## Test plan

- [x] `clang-format --dry-run -Werror` clean.
- [x] CI (this sandbox has no PlatformIO registry access; this is a two-line comment deletion with zero code change, so risk is effectively nil).


---
_Generated by [Claude Code](https://claude.ai/code/session_018Cy1xDgHWhw68D9NuojDuG)_